### PR TITLE
fix: restore image loading and viewer safe-area layout

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -104,6 +104,7 @@ dependencies {
     implementation(libs.threeTenAbp)
 
     implementation(libs.coilCompose)
+    implementation(libs.coilNetworkKtor3)
 
     implementation(libs.ktorClientCore)
     implementation(libs.ktorClientCio)

--- a/app/src/main/java/com/jawnnypoo/openmeh/App.kt
+++ b/app/src/main/java/com/jawnnypoo/openmeh/App.kt
@@ -5,6 +5,9 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.network.ktor3.KtorNetworkFetcherFactory
 import com.jakewharton.threetenabp.AndroidThreeTen
 import com.jawnnypoo.openmeh.data.GitHubRepository
 import com.jawnnypoo.openmeh.data.MehRepository
@@ -37,6 +40,7 @@ class App : Application() {
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         }
+        setupImageLoader()
         Prefs.init(this)
         AndroidThreeTen.init(this)
         meh = MehClient(BuildConfig.MEH_API_KEY, BuildConfig.DEBUG)
@@ -45,6 +49,16 @@ class App : Application() {
         gitHubRepository = GitHubRepository(gitHubClient)
 
         setupNotificationChannelsIfNeeded(this)
+    }
+
+    private fun setupImageLoader() {
+        SingletonImageLoader.setSafe {
+            ImageLoader.Builder(this)
+                .components {
+                    add(KtorNetworkFetcherFactory())
+                }
+                .build()
+        }
     }
 
     private fun setupNotificationChannelsIfNeeded(context: Context) {

--- a/app/src/main/java/com/jawnnypoo/openmeh/ui/screen/FullScreenImageViewerScreen.kt
+++ b/app/src/main/java/com/jawnnypoo/openmeh/ui/screen/FullScreenImageViewerScreen.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
@@ -57,6 +59,7 @@ fun FullScreenImageViewerScreen(
             Row(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
+                    .navigationBarsPadding()
                     .padding(bottom = 24.dp),
                 horizontalArrangement = Arrangement.Center,
             ) {
@@ -81,6 +84,7 @@ fun FullScreenImageViewerScreen(
             onClick = onClose,
             modifier = Modifier
                 .align(Alignment.TopStart)
+                .statusBarsPadding()
                 .padding(8.dp),
         ) {
             Icon(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ materialComponents = { module = "com.google.android.material:material", version.
 threeTenAbp = { module = "com.jakewharton.threetenabp:threetenabp", version.ref = "threeTenAbp" }
 
 coilCompose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coilNetworkKtor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 
 ktorClientCore = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktorClientCio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }


### PR DESCRIPTION
## Summary
- configure Coil 3 network fetching explicitly with `coil-network-ktor3`
- initialize a singleton `ImageLoader` in `App` with `KtorNetworkFetcherFactory`
- fix full-screen image viewer controls to respect system bars:
  - close button now uses `statusBarsPadding()`
  - page indicators now use `navigationBarsPadding()`

## Why
- images were not loading reliably after Coil 3 migration due missing network fetcher setup
- close button and page dots overlapped status/navigation bar areas on full-screen viewer

## Verification
- `./gradlew :app:assembleDebug`
- `./gradlew :app:lintDebug`
